### PR TITLE
i18n plugin: swap "code" for "lang"

### DIFF
--- a/src/docs/plugins/i18n.md
+++ b/src/docs/plugins/i18n.md
@@ -262,11 +262,11 @@ module.exports = function(data) {
 
 ### `locale_links` Filter
 
-Returns an array of the relevant alternative content for a specified URL (or, defaults to the current page). The original page passed to the filter is _not_ included in the results. Each array entry is an object with `url`, `code`, and (localized) `label` properties, for example:
+Returns an array of the relevant alternative content for a specified URL (or, defaults to the current page). The original page passed to the filter is _not_ included in the results. Each array entry is an object with `url`, `lang`, and (localized) `label` properties, for example:
 
 ```json
 [
-  {"url":"/es/blog/","code":"es","label":"Español"}
+  {"url":"/es/blog/","lang":"es","label":"Español"}
 ]
 ```
 


### PR DESCRIPTION
swapped code for lang  in locale_links filter, as the returned array is actually: {"url":"/es/blog/","lang":"es","label":"Español"}